### PR TITLE
add file in config/initializers called timeconversion to format unix …

### DIFF
--- a/app/views/buildings/building_profile.html.erb
+++ b/app/views/buildings/building_profile.html.erb
@@ -65,7 +65,7 @@
                 <% elsif  report.class.to_s == "Harassment"  %>
                   <h4 class="type-of-comment">Landlord Harassment</h4><br>
                 <% end %>
-                <span class="created"><%= report.created_at.strftime("%b %d, %Y") %></span> | Comment: <span class="report_comment"><%= report.comment %></span>
+                <span class="created"><%= report.created_at %></span> | Comment: <span class="report_comment"><%= report.comment %></span>
               </div>
             <% end %>
           <% end %>

--- a/config/initializers/timeconversion.rb
+++ b/config/initializers/timeconversion.rb
@@ -1,0 +1,6 @@
+class ActiveSupport::TimeWithZone
+    def as_json(options = {})
+        strftime("%b %d, %Y")
+    end
+end
+

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -1,4 +1,4 @@
-# encoding: UTF-8
+  # encoding: UTF-8
 # This file is auto-generated from the current state of the database. Instead
 # of editing this file, please use the migrations feature of Active Record to
 # incrementally modify your database, and then regenerate this schema definition.


### PR DESCRIPTION
…time from db to json. deleted strftime in building view

Interesting problem. Active record gives UTC time which could either be formatted in rails or in JS. The JS solution was long and nasty. The Rails solution was very tidy. Found this as a resource http://stackoverflow.com/questions/2937740/rails-dates-with-json but also could have used a helper method in Rails.  

Solution in our app is to  add a file in the config/initializers folder with just a formatting method.
